### PR TITLE
Support for Gitlab cancellation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,6 @@ serde_json = "1.0.68"
 serde_yaml = "0.9"
 rand = "0.8.4"
 tempfile = "3.3.0"
+tokio-util = { version = "0.7", features = [ "io" ] }
 tracing-subscriber = { version = "0.3.9", features = [ "env-filter"] }
 tracing = "0.1.31"

--- a/src/throttled.rs
+++ b/src/throttled.rs
@@ -240,6 +240,11 @@ impl ThrottledLava {
         job::submit_job(&self.inner, definition).await
     }
 
+    pub async fn cancel_job(&self, job: i64) -> Result<(), job::CancellationError> {
+        let _permit = self.throttler.acquire("cancel_job").await;
+        job::cancel_job(&self.inner, job).await
+    }
+
     pub async fn workers(&self) -> Throttled<Paginator<Worker>> {
         let permit = self.throttler.acquire("workers").await;
         Throttled::new(self.inner.workers(), permit)


### PR DESCRIPTION
At present, if a job is cancelled in Gitlab, the LAVA jobs are not cancelled; in fact the framework makes no attempt to detect cancellation or respond to it. This can leave LAVA submission queues clogged with jobs whose output is not of interest.

The cancellation behaviour can be customised by setting LAVA_CANCELLATION in the Gitlab job. The options are 'cancel' to cancel any pending LAVA jobs, and 'ignore' to leave the LAVA jobs running. The default behaviour is to cancel jobs run via 'submit', and to leave jobs running for jobs running under 'monitor'.