### PR TITLE
Allow LAVA jobs to pass artifacts back to the runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,14 @@ homepage = "https://gitlab.collabora.com/lava/lava-gitlab-runner"
 repository = "https://gitlab.collabora.com/lava/lava-gitlab-runner.git"
 
 [dependencies]
+axum = "0.6"
 bytes = "1.2.0"
 chrono = { version = "0.4", features = ["serde"] }
 colored = "2"
 gitlab-runner = "0.0.8"
 lava-api = "0.1.1"
 lazy_static = "1.4"
+local-ip-address = "0.5"
 structopt = "0.3.23"
 url = "2.2.2"
 tokio = "1.12.0"
@@ -27,6 +29,7 @@ serde = { version = "^1.0.97", features = ["derive"] }
 serde_json = "1.0.68"
 serde_yaml = "0.9"
 rand = "0.8.4"
+rand_chacha = "0.3"
 tempfile = "3.3.0"
 tokio-util = { version = "0.7", features = [ "io" ] }
 tracing-subscriber = { version = "0.3.9", features = [ "env-filter"] }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,0 +1,112 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, Weak};
+
+use bytes::Bytes;
+use rand::distributions::Alphanumeric;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+use tracing::warn;
+
+pub struct UploadServer {
+    rng: ChaCha20Rng,
+    job_cache: BTreeMap<String, Weak<Mutex<JobArtifacts>>>,
+    base_addr: Option<String>,
+}
+
+impl UploadServer {
+    pub fn new() -> Self {
+        Self {
+            rng: ChaCha20Rng::from_entropy(),
+            job_cache: Default::default(),
+            base_addr: None,
+        }
+    }
+
+    pub fn add_new_job(&mut self) -> Arc<Mutex<JobArtifacts>> {
+        // Wipe any dead jobs as the new one starts. It's not hugely
+        // important when this happens, so long as it happens
+        // periodically.
+        self.cleanup();
+
+        let prefix = self.generate_unique_id();
+        let base_addr = self
+            .base_addr
+            .as_ref()
+            .expect("failed to set base_address on UploadServer before adding jobs.");
+        let url = format!("https://{}/artifacts/{}/", base_addr, prefix);
+        let ja: Arc<Mutex<JobArtifacts>> = Arc::new(Mutex::new(JobArtifacts::new(url)));
+        self.job_cache.insert(prefix, Arc::downgrade(&ja));
+        ja
+    }
+
+    pub fn set_base_address(&mut self, base_addr: String) {
+        self.base_addr = Some(base_addr);
+    }
+
+    pub fn upload_file(&mut self, key: &str, path: &str, data: Bytes) {
+        if let Some(ja) = self.job_cache.get(key).and_then(Weak::upgrade) {
+            ja.lock().unwrap().upload_artifact(path, data)
+        } else {
+            warn!(
+                "Ignoring attempt to upload {} for non-existent or expired job",
+                path
+            );
+        }
+    }
+
+    fn generate_unique_id(&mut self) -> String {
+        (&mut self.rng)
+            .sample_iter(&Alphanumeric)
+            .take(64)
+            .map(char::from)
+            .collect()
+    }
+
+    pub fn cleanup(&mut self) {
+        let mut cleaned = Vec::new();
+        for (k, v) in self.job_cache.iter() {
+            if v.strong_count() == 0 {
+                cleaned.push(k.clone());
+            }
+        }
+        for k in cleaned {
+            self.job_cache.remove(&k);
+        }
+    }
+}
+
+impl Default for UploadServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct JobArtifacts {
+    artifacts: BTreeMap<String, Bytes>,
+    url: String,
+}
+
+impl JobArtifacts {
+    fn new(url: String) -> Self {
+        JobArtifacts {
+            artifacts: Default::default(),
+            url,
+        }
+    }
+
+    pub fn get_upload_url(&self) -> &str {
+        &self.url
+    }
+
+    pub fn get_artifact_paths(&self) -> impl Iterator<Item = &str> {
+        self.artifacts.iter().map(|x| x.0.as_ref())
+    }
+
+    pub fn get_artifact_data(&self, path: &str) -> Option<Bytes> {
+        self.artifacts.get(path).map(Clone::clone)
+    }
+
+    pub fn upload_artifact(&mut self, path: &str, data: Bytes) {
+        self.artifacts.insert(path.to_string(), data);
+    }
+}


### PR DESCRIPTION
We'd like to potentially add artifacts created by LAVA jobs to the archive stored by Gitlab. To achieve this, we run a cut-down web server on the lava-gitlab-runner that is able to respond to POST requests at

   http://<runner ip:ephemeral port>/<key>/artifacts/

The LAVA job is able to know the upload URL because we introduce a new namespace for templated variables `runner` in the lava-gitlab-runner and add `ARTIFACT_UPLOAD_URL` to it.

It's still relatively complicated to get variables into LAVA tests; the pattern I used in my test repository

   https://gitlab.collabora.com/eds/callback-tests

is to create a parameter called `CALLBACK_URL` in the test itself, and then in the job we can use a stanza like:

```yaml
   test: foo
     parameters:
       CALLBACK_URL: {{ '{{ runner.ARTIFACT_UPLOAD_URL }}' }}
```

to make it available to the test. Bear in mind, if you use this that LAVA does not automatically export parameters from environment variables so you will need to export it inside your `steps:` in your test if you want to use it in scripts.

The `key` part of the upload URL is a long random string. It's generated uniquely per Gitlab job, not per LAVA job, although this detail is not important unless you are performing multi-node tests.

Because of the dynamic nature of the key, and the runner's port and IP, artifact upload is only possible for `submit` jobs. For `monitor` jobs, there's simply no way to communicate the necessary URL to them.

Backing the webserver, there is a shared `UploadServer` that stores the uploaded artifacts, and bridges between the web server thread and the job thread. It stores a `JobArtifacts` for each active job, which the `ArtifactStore` can query when we come to upload files. I've elected to put the uploaded artifacts at:

  `<job_id>_artifacts/`

in the archive, to match the other uploads which also lead with the job ID. Note however that it will require some significant reworking to support distinct directories for multi-node jobs. That's because we do not know how many nodes there are in the job until after we submit, at which point it's too late to create new keys for the other jobs. We could speculatively create a surplus, for example, but we couldn't then tie them to job IDs anyway.

For the generated upload URL, note that you can use the environment variables `LAVA_GITLAB_RUNNER_ROUTABLE_HOST`,
`LAVA_GITLAB_RUNNER_ROUTABLE_PORT` to specify an arbitrary external address, for example for an appropriate reverse proxy. Also the upload URL will always be `https`, even though the service itself does not have TLS support.

Signed-off-by: Ed Smith <ed.smith@collabora.com>