### PR TITLE
Run the service with the least privilege

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update \
 FROM debian:bullseye-slim
 ARG DEBIAN_FRONTEND=noninteractive
 
+RUN adduser --uid 1001 --group --no-create-home --home /app lava-gitlab-runner
+
 RUN apt update && apt install -y libssl1.1 ca-certificates
 COPY --from=build /app/target/release/lava-gitlab-runner /usr/local/bin
+
+USER lava-gitlab-runner
 
 ENTRYPOINT [ "/usr/local/bin/lava-gitlab-runner" ]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -30,13 +30,16 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  fsGroup: 1001
+  runAsUser: 1001
+  runAsGroup: 1001
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Run the container as user 1001 instead of user root.
Configure SecurityContext to deploy the service in k8s using a non-root user.
Allow running the service with the least privilege.