### PR TITLE
Release 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lava-gitlab-runner"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Sjoerd Simons <sjoerd@collabora.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,7 +19,7 @@ image:
   repository: ghcr.io/collabora/lava-gitlab-runner
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.3.0"
+  tag: "v0.3.1"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Changelog:

* cargo: update dependencies
* helm: run with lower privileges, make the rootfs read-only
* helm: automatically rollout the deployment when the secret changes
* ci: move to actively maintained Rust actions
* ci: bump version for a few actions
* ci: move from bors to GitHub merge queues