### PR TITLE
fix incorrectly placed fsgroup in helm chart

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -28,7 +28,7 @@ fullnameOverride: ""
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
+  fsGroup: 1001
 
 securityContext:
   capabilities:
@@ -37,7 +37,6 @@ securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   allowPrivilegeEscalation: false
-  fsGroup: 1001
   runAsUser: 1001
   runAsGroup: 1001
 


### PR DESCRIPTION
The `fsGroup` option was not set in the correct part of the Helm chart and was discarded during the deployment. 
This change correctly allocates the `fsGroup` parameter and will be set in the deployment.