### PR TITLE
ci: Prevent dependabot from messing with our MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
+        with:
+          toolchain: "1.70"
       - run: cargo check --all-targets --all-features
 
   fmt:
@@ -24,8 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
+          toolchain: "1.70"
           components: rustfmt
       - run: cargo fmt --all --check
 
@@ -34,7 +37,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
+        with:
+          toolchain: "1.70"
       - run: cargo test --all-targets --all-features
 
   clippy:
@@ -42,8 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70
+      - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
+          toolchain: "1.70"
           components: clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings
 


### PR DESCRIPTION
When using `dtolnay/rust-toolchain@1.70` dependabot helpfully tries to update it to the latest tag, but we really want to stick to 1.70 in that case since it is our Minimum Supported Rust Version, to match what it is being currently shipped in Debian testing.

See https://github.com/collabora/lava-gitlab-runner/pull/36 for @dependabot well-intentioned mistake.