### PR TITLE
Fix podSecurityContext in values

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -27,7 +27,7 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
   fsGroup: 1001
 
 securityContext:


### PR DESCRIPTION
An error in the last commit was included in `values.yaml`, leaving the `{}` after `podSecurityContext`. 
This problem induces an error of being unable to parse the `values.yaml` file.