### PR TITLE
Release 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lava-gitlab-runner"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Sjoerd Simons <sjoerd@collabora.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,7 +19,7 @@ image:
   repository: ghcr.io/collabora/lava-gitlab-runner
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.3.1"
+  tag: "v0.3.2"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Highlights:

* helm: avoid deployment errors due to misplaced `fsGroup`
* ci: Prevent dependabot from messing with our MSRV