### PR TITLE
ci: Bump rust toolchain to 1.83

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
-          toolchain: "1.70"
+          toolchain: "1.83"
       - run: cargo check --all-targets --all-features
 
   fmt:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
-          toolchain: "1.70"
+          toolchain: "1.83"
           components: rustfmt
       - run: cargo fmt --all --check
 
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
-          toolchain: "1.70"
+          toolchain: "1.83"
       - run: cargo test --all-targets --all-features
 
   clippy:
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master # avoid the tag here to prevent dependabot from updating it
         with:
-          toolchain: "1.70"
+          toolchain: "1.83"
           components: clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/src/throttled.rs
+++ b/src/throttled.rs
@@ -29,7 +29,7 @@ struct PermitDebug<'a> {
 }
 
 #[cfg(debug_assertions)]
-impl<'a> Drop for PermitDebug<'a> {
+impl Drop for PermitDebug<'_> {
     fn drop(&mut self) {
         match self.start {
             Some(start) => {
@@ -275,7 +275,7 @@ impl<'a, T> Throttled<'a, T> {
     }
 }
 
-impl<'a, T> core::ops::Deref for Throttled<'a, T> {
+impl<T> core::ops::Deref for Throttled<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -283,13 +283,13 @@ impl<'a, T> core::ops::Deref for Throttled<'a, T> {
     }
 }
 
-impl<'a, T> core::ops::DerefMut for Throttled<'a, T> {
+impl<T> core::ops::DerefMut for Throttled<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         &mut self.inner
     }
 }
 
-impl<'a, T> futures::stream::Stream for Throttled<'a, T>
+impl<T> futures::stream::Stream for Throttled<'_, T>
 where
     T: futures::stream::Stream + Unpin,
 {


### PR DESCRIPTION
Matching Debian testing

Also remove unnecessary lifetimes from `throttled.rs`