### PR TITLE
feat: clean up Dockerfile and reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
 FROM rust:1-slim-bookworm AS build
-ARG DEBIAN_FRONTEND=noninteractive
 
-ADD . /app
 WORKDIR /app
-RUN apt-get update \
-  && apt-get install -y pkg-config libssl-dev cmake \
-  && cargo build --release
+COPY . .
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends pkg-config libssl-dev cmake && \
+    cargo build --release
 
 FROM debian:bookworm-slim
-ARG DEBIAN_FRONTEND=noninteractive
 
-RUN adduser --uid 1001 --group --no-create-home --home /app lava-gitlab-runner
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libssl3 ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -g 1001 lava-gitlab-runner && \
+    useradd -u 1001 -g lava-gitlab-runner -d /app -M lava-gitlab-runner
 
-RUN apt update && apt install -y libssl3 ca-certificates
-COPY --from=build /app/target/release/lava-gitlab-runner /usr/local/bin
+COPY --from=build /app/target/release/lava-gitlab-runner /usr/local/bin/
 
 USER lava-gitlab-runner
 
-ENTRYPOINT [ "/usr/local/bin/lava-gitlab-runner" ]
+ENTRYPOINT ["/usr/local/bin/lava-gitlab-runner"]


### PR DESCRIPTION
- Replace ADD with COPY to avoid unnecessary behaviors
- Install packages with --no-install-recommends to keep images slim
- Clean up apt lists to reduce image size
- Simplify user creation (fixes #105)

